### PR TITLE
Reset status bar highlighting after displaying error message

### DIFF
--- a/plugin/togglelist.vim
+++ b/plugin/togglelist.vim
@@ -38,6 +38,7 @@ function! ToggleLocationList()
   catch /E776/
       echohl ErrorMsg 
       echo "Location List is Empty."
+      echohl None
       return
   endtry
   if winbufnr(0) == nextbufnr


### PR DESCRIPTION
Fixes status bar being colored like an error message after the
"Location List is Empty" error is shown.
