### PR TITLE
Allow the mappings to be skipped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The default mappings are:
     nmap <script> <silent> <leader>l :call ToggleLocationList()<CR>
     nmap <script> <silent> <leader>q :call ToggleQuickfixList()<CR>
 
-You can easily unmap these and remap them if you want, both `ToggleLocationList` and `ToggleQuickfixList` are global functions. I imagine the names of the functions are self-explanatory.
+You can prevent these mappings by setting `g:toggle_list_no_mappings` in your `.vimrc` and then remap them if you want--both `ToggleLocationList` and `ToggleQuickfixList` are global functions. I imagine the names of the functions are self-explanatory.
 
 After opening or closing either list, the previous window is restored so you can still use `<C-w>p`.
 

--- a/plugin/togglelist.vim
+++ b/plugin/togglelist.vim
@@ -70,8 +70,10 @@ function! ToggleQuickfixList()
   endif
 endfunction
 
-nmap <script> <silent> <leader>l :call ToggleLocationList()<CR>
-nmap <script> <silent> <leader>q :call ToggleQuickfixList()<CR>
+if !exists("g:toggle_list_no_mappings")
+    nmap <script> <silent> <leader>l :call ToggleLocationList()<CR>
+    nmap <script> <silent> <leader>q :call ToggleQuickfixList()<CR>
+endif
 
 
 


### PR DESCRIPTION
As a plugin, this can easily collide with a user's existing mapping.
Instead, let's introduce a variable to prevent setting up the mappings.

I've been playing with Syntastic and wanted a way to toggle the location list, but your plugin ended up stomping over some existing mappings that I love.  This change allows me to setup my own mappings without stomping on `<Leader>q` and `<Leader>l`.
