### PR TITLE
Fix: detect unlist buffer

### DIFF
--- a/plugin/togglelist.vim
+++ b/plugin/togglelist.vim
@@ -15,7 +15,7 @@ endif
 
 function! s:GetBufferList() 
   redir =>buflist 
-  silent! ls 
+  silent! ls! 
   redir END 
   return buflist 
 endfunction


### PR DESCRIPTION
There is a bug that prevents the plugin from detecting the quickfix window. STR:

1. Open a tab, run `:copen`.
2. Open the second tab, run `:copen`.
3. Run `:cclose`.
4. Switch to the first tab, run `:ls`.

Result:

The quickfix window is still opened, but you can't see it from `:ls`. However, it seems that we can see it using `:ls!`.

Not sure if this is the correct solution. I think it makes more sense to have a function that returns buffers in the current tab.